### PR TITLE
fix: Directive ɵa, Expected 0 arguments, but got 1 build-error

### DIFF
--- a/src/lib/directive/ngxf-select.directive.ts
+++ b/src/lib/directive/ngxf-select.directive.ts
@@ -32,7 +32,7 @@ export class NgxfSelectDirective implements AfterViewInit, OnDestroy {
     private _elm: ElementRef
   ) { }
 
-  @HostListener('click', ['$event']) click() {
+  @HostListener('click') click() {
     this.bindBeforeClick();
 
     this.fileElm.click();


### PR DESCRIPTION
While using your library I received following error while building with `ng-packagr`: 
> Directive ɵa, Expected 0 arguments, but got 1.

After a small research I think I found the cause of this error.  
The hostlistener on line [35](https://github.com/ZouYouShun/ngxf-uploader/blob/master/src/lib/directive/ngxf-select.directive.ts#L35) of `ngxf-select` should not define the event without passing it to the click function. 

Due to the project structure I could not test the change so it would be nice if you could test it and create a new release.

For further information on the error please see
https://github.com/swimlane/ngx-dnd/issues/83
https://github.com/swimlane/ngx-dnd/pull/84
